### PR TITLE
Add support for build.gradle.kts file. Bump version 0.4.1.

### DIFF
--- a/lib/fastlane/plugin/android_version_manager/actions/android_base_action.rb
+++ b/lib/fastlane/plugin/android_version_manager/actions/android_base_action.rb
@@ -1,0 +1,34 @@
+require "fastlane/action"
+require_relative "../helper/android_version_manager_helper"
+
+module Fastlane
+  module Actions
+    class AndroidBaseAction < Action
+      def self.authors
+        ["Jonathan Cardoso", "@_jonathancardos", "JCMais", "Nicolas Verinaud"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+
+      def self.app_project_dir_action
+        FastlaneCore::ConfigItem.new(
+          key: :app_project_dir,
+          env_name: "FL_ANDROID_GET_VERSION_CODE_APP_PROJECT_DIR",
+          description: "The path to the application source folder in the Android project (default: android/app)",
+          optional: true,
+          type: String,
+          default_value: "android/app",
+          verify_block: proc do |value|
+            UI.user_error!("Couldn't find build.gradle or build.gradle.kts file at path '#{value}'") unless Helper::AndroidVersionManagerHelper.build_gradle_exists?(value)
+          end
+        )
+      end
+
+      def self.find_build_gradle(app_project_dir)
+        Helper::AndroidVersionManagerHelper.find_build_gradle(app_project_dir)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/android_version_manager/actions/android_get_value_from_build_action.rb
+++ b/lib/fastlane/plugin/android_version_manager/actions/android_get_value_from_build_action.rb
@@ -1,39 +1,23 @@
-# This source code is based on this one:
-# https://github.com/otkmnb2783/fastlane-plugin-android_versioning/blob/a9dc02d69a8c3a106d00b52ace78d4a763baf6af/lib/fastlane/plugin/android_versioning/actions/get_value_from_build.rb#L1
-require "fileutils"
+require_relative 'android_base_action'
+require_relative '../helper/android_version_manager_helper'
 
 module Fastlane
   module Actions
-    class AndroidGetValueFromBuildAction < Action
+    class AndroidGetValueFromBuildAction < AndroidBaseAction
       def self.run(params)
         app_project_dir ||= params[:app_project_dir]
-        value, _line, _line_index = Helper::AndroidVersionManagerHelper.get_key_from_gradle_file("#{app_project_dir}/build.gradle", params[:key])
+        file_path = find_build_gradle(app_project_dir)
+        value, _line, _line_index = Helper::AndroidVersionManagerHelper.get_key_from_gradle_file(file_path, params[:key])
         return value
       end
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_project_dir,
-                                       description: "The path to the application source folder in the Android project, the one that contains the build.gradle file (default: android/app)",
-                                       optional: true,
-                                       type: String,
-                                       default_value: "android/app",
-                                       verify_block: proc do |value|
-                                         # Not using File.exist?("#{value}/build.gradle") because it does not handle globs
-                                         UI.user_error!("Couldn't find build.gradle file at path '#{value}'") unless Dir["#{value}/build.gradle"].any?
-                                       end),
+          app_project_dir_action,
           FastlaneCore::ConfigItem.new(key: :key,
                                        description: "The property key to retrieve the value from",
                                        type: String),
         ]
-      end
-
-      def self.authors
-        ["Jonathan Cardoso", "@_jonathancardos", "JCMais"]
-      end
-
-      def self.is_supported?(platform)
-        platform == :android
       end
     end
   end

--- a/lib/fastlane/plugin/android_version_manager/actions/android_get_version_code_action.rb
+++ b/lib/fastlane/plugin/android_version_manager/actions/android_get_version_code_action.rb
@@ -1,4 +1,4 @@
-require "fastlane/action"
+require_relative 'android_base_action'
 require_relative "../helper/android_version_manager_helper"
 
 module Fastlane
@@ -8,14 +8,15 @@ module Fastlane
       ANDROID_VERSION_CODE ||= :ANDROID_VERSION_CODE
     end
 
-    class AndroidGetVersionCodeAction < Action
+    class AndroidGetVersionCodeAction < AndroidBaseAction
       def self.run(params)
         # fastlane will take care of reading in the parameter and fetching the environment variable:
         UI.message("Parameter app_project_dir: #{params[:app_project_dir]}")
         UI.message("Parameter key: #{params[:key]}")
 
+        file_path = find_build_gradle(params[:app_project_dir])
         # We can expect version_code to be an existing and valid version code
-        version_code = Helper::AndroidVersionManagerHelper.get_version_code_from_gradle_file("#{params[:app_project_dir]}/build.gradle", params[:key])
+        version_code = Helper::AndroidVersionManagerHelper.get_version_code_from_gradle_file(file_path, params[:key])
 
         Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE] = version_code
 
@@ -36,16 +37,7 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_project_dir,
-                                       env_name: "FL_ANDROID_GET_VERSION_CODE_APP_PROJECT_DIR",
-                                       description: "The path to the application source folder in the Android project (default: android/app)",
-                                       optional: true,
-                                       type: String,
-                                       default_value: "android/app",
-                                       verify_block: proc do |value|
-                                         # Not using File.exist?("#{value}/build.gradle") because it does not handle globs
-                                         UI.user_error!("Couldn't find build.gradle file at path '#{value}'") unless Dir["#{value}/build.gradle"].any?
-                                       end),
+          app_project_dir_action,
           FastlaneCore::ConfigItem.new(key: :key,
                                        env_name: "FL_ANDROID_GET_VERSION_CODE_KEY",
                                        description: "The property key",
@@ -83,14 +75,6 @@ module Fastlane
       def self.return_type
         # https://github.com/fastlane/fastlane/blob/051e5012984d97257571a76627c1261946afb8f8/fastlane/lib/fastlane/action.rb#L23-L30
         :int
-      end
-
-      def self.authors
-        ["Jonathan Cardoso", "@_jonathancardos", "JCMais"]
-      end
-
-      def self.is_supported?(platform)
-        platform == :android
       end
     end
   end

--- a/lib/fastlane/plugin/android_version_manager/actions/android_increment_version_code_action.rb
+++ b/lib/fastlane/plugin/android_version_manager/actions/android_increment_version_code_action.rb
@@ -1,4 +1,4 @@
-require "fastlane/action"
+require_relative 'android_base_action'
 require_relative "../helper/android_version_manager_helper"
 
 module Fastlane
@@ -8,13 +8,13 @@ module Fastlane
       ANDROID_VERSION_CODE ||= :ANDROID_VERSION_CODE
     end
 
-    class AndroidIncrementVersionCodeAction < Action
+    class AndroidIncrementVersionCodeAction < AndroidBaseAction
       def self.run(params)
         UI.message("Param app_project_dir: #{params[:app_project_dir]}")
         UI.message("Param version_code: #{params[:version_code]}")
         UI.message("Param key: #{params[:key]}")
 
-        file_path = "#{params[:app_project_dir]}/build.gradle"
+        file_path = find_build_gradle(params[:app_project_dir])
 
         # We can expect version_code to be an existing and valid version code
         version_code = Helper::AndroidVersionManagerHelper.get_version_code_from_gradle_file(file_path, params[:key])
@@ -45,16 +45,7 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_project_dir,
-                                       env_name: "FL_ANDROID_INCREMENT_VERSION_CODE_APP_PROJECT_DIR",
-                                       description: "The path to the application source folder in the Android project (default: android/app)",
-                                       optional: true,
-                                       type: String,
-                                       default_value: "android/app",
-                                       verify_block: proc do |value|
-                                         # Not using File.exist?("#{value}/build.gradle") because it does not handle globs
-                                         UI.user_error!("Couldn't find build.gradle file at path '#{value}'") unless Dir["#{value}/build.gradle"].any?
-                                       end),
+          app_project_dir_action,
           FastlaneCore::ConfigItem.new(key: :key,
                                        env_name: "FL_ANDROID_INCREMENT_VERSION_CODE_KEY",
                                        description: "The property key",
@@ -97,14 +88,6 @@ module Fastlane
       def self.return_type
         # https://github.com/fastlane/fastlane/blob/051e5012984d97257571a76627c1261946afb8f8/fastlane/lib/fastlane/action.rb#L23-L30
         :int
-      end
-
-      def self.authors
-        ["Jonathan Cardoso", "@_jonathancardos", "JCMais"]
-      end
-
-      def self.is_supported?(platform)
-        platform == :android
       end
     end
   end

--- a/lib/fastlane/plugin/android_version_manager/actions/android_increment_version_name_action.rb
+++ b/lib/fastlane/plugin/android_version_manager/actions/android_increment_version_name_action.rb
@@ -1,6 +1,5 @@
-require "fastlane/action"
 require "semantic"
-
+require_relative 'android_base_action'
 require_relative "../helper/android_version_manager_helper"
 
 module Fastlane
@@ -10,14 +9,14 @@ module Fastlane
       ANDROID_VERSION_NAME ||= :ANDROID_VERSION_NAME
     end
 
-    class AndroidIncrementVersionNameAction < Action
+    class AndroidIncrementVersionNameAction < AndroidBaseAction
       def self.run(params)
         UI.message("Param app_project_dir: #{params[:app_project_dir]}")
         UI.message("Param version_name: #{params[:version_name]}")
         UI.message("Param increment_type: #{params[:increment_type]}")
         UI.message("Param key: #{params[:key]}")
 
-        file_path = "#{params[:app_project_dir]}/build.gradle"
+        file_path = find_build_gradle(params[:app_project_dir])
         increment_type = params[:increment_type].to_sym
 
         # We can expect version_code to be an existing and valid version code
@@ -58,16 +57,7 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_project_dir,
-                                       env_name: "FL_ANDROID_INCREMENT_VERSION_NAME_APP_PROJECT_DIR",
-                                       description: "The path to the application source folder in the Android project (default: android/app)",
-                                       optional: true,
-                                       type: String,
-                                       default_value: "android/app",
-                                       verify_block: proc do |value|
-                                         # Not using File.exist?("#{value}/build.gradle") because it does not handle globs
-                                         UI.user_error!("Couldn't find build.gradle file at path '#{value}'") unless Dir["#{value}/build.gradle"].any?
-                                       end),
+          app_project_dir_action,
           FastlaneCore::ConfigItem.new(key: :key,
                                        env_name: "FL_ANDROID_INCREMENT_VERSION_NAME_KEY",
                                        description: "The property key",
@@ -119,14 +109,6 @@ module Fastlane
       def self.return_type
         # https://github.com/fastlane/fastlane/blob/051e5012984d97257571a76627c1261946afb8f8/fastlane/lib/fastlane/action.rb#L23-L30
         :int
-      end
-
-      def self.authors
-        ["Jonathan Cardoso", "@_jonathancardos", "JCMais"]
-      end
-
-      def self.is_supported?(platform)
-        platform == :android
       end
     end
   end

--- a/lib/fastlane/plugin/android_version_manager/actions/android_version_manager_action.rb
+++ b/lib/fastlane/plugin/android_version_manager/actions/android_version_manager_action.rb
@@ -1,19 +1,15 @@
-require 'fastlane/action'
+require_relative 'android_base_action'
 require_relative '../helper/android_version_manager_helper'
 
 module Fastlane
   module Actions
-    class AndroidVersionManagerAction < Action
+    class AndroidVersionManagerAction < AndroidBaseAction
       def self.run(params)
         UI.message("The android_version_manager plugin is working!")
       end
 
       def self.description
         "Android's App Version Managment"
-      end
-
-      def self.authors
-        ["Jonathan Cardoso Machado"]
       end
 
       def self.return_value
@@ -27,21 +23,8 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_project_dir,
-                                  env_name: "ANDROID_VERSIONING_APP_PROJECT_DIR",
-                               description: "The path to the application source folder in the Android project (default: android/app)",
-                                  optional: true,
-                                      type: String,
-                             default_value: "android/app"),
-          FastlaneCore::ConfigItem.new(key: :key,
-                               description: "The property key",
-                                      type: String)
-
+          app_project_dir_action
         ]
-      end
-
-      def self.is_supported?(platform)
-        platform == :android
       end
     end
   end

--- a/lib/fastlane/plugin/android_version_manager/helper/android_version_manager_helper.rb
+++ b/lib/fastlane/plugin/android_version_manager/helper/android_version_manager_helper.rb
@@ -10,7 +10,6 @@ module Fastlane
   module Helper
     class AndroidVersionManagerHelper
       def self.build_gradle_exists?(app_project_dir)
-        # Not using File.exist?("#{value}/build.gradle") because it does not handle globs
         return BuildGradleFile.new(app_project_dir).exists?
       end
 

--- a/lib/fastlane/plugin/android_version_manager/helper/android_version_manager_helper.rb
+++ b/lib/fastlane/plugin/android_version_manager/helper/android_version_manager_helper.rb
@@ -9,6 +9,15 @@ module Fastlane
 
   module Helper
     class AndroidVersionManagerHelper
+      def self.build_gradle_exists?(app_project_dir)
+        # Not using File.exist?("#{value}/build.gradle") because it does not handle globs
+        return BuildGradleFile.new(app_project_dir).exists?
+      end
+
+      def self.find_build_gradle(app_project_dir)
+        return BuildGradleFile.new(app_project_dir).find
+      end
+
       # class methods that you define here become available in your action
       # as `Helper::AndroidVersionManagerHelper.your_method`
       # Most actions code are here to follow this advice: https://docs.fastlane.tools/advanced/actions/#calling-other-actions

--- a/lib/fastlane/plugin/android_version_manager/helper/build_gradle_file.rb
+++ b/lib/fastlane/plugin/android_version_manager/helper/build_gradle_file.rb
@@ -12,7 +12,6 @@ class BuildGradleFile
   end
 
   def exists?
-    # Not using File.exist? because it does not handle globs
     return kts_exists? || classic_exists?
   end
 
@@ -33,6 +32,7 @@ class BuildGradleFile
   end
 
   def file_exists?(path)
+    # Not using File.exist? because it does not handle globs
     return Dir[path].any?
   end
 end

--- a/lib/fastlane/plugin/android_version_manager/helper/build_gradle_file.rb
+++ b/lib/fastlane/plugin/android_version_manager/helper/build_gradle_file.rb
@@ -1,0 +1,38 @@
+
+class BuildGradleFile
+  def initialize(app_project_dir)
+    @app_project_dir = app_project_dir
+  end
+
+  def find
+    if kts_exists?
+      return kts
+    end
+    return classic
+  end
+
+  def exists?
+    # Not using File.exist? because it does not handle globs
+    return kts_exists? || classic_exists?
+  end
+
+  def kts_exists?
+    return file_exists?(kts)
+  end
+
+  def classic_exists?
+    return file_exists?(classic)
+  end
+
+  def kts
+    return "#{@app_project_dir}/build.gradle.kts"
+  end
+
+  def classic
+    return "#{@app_project_dir}/build.gradle"
+  end
+
+  def file_exists?(path)
+    return Dir[path].any?
+  end
+end

--- a/lib/fastlane/plugin/android_version_manager/version.rb
+++ b/lib/fastlane/plugin/android_version_manager/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module AndroidVersionManager
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end

--- a/spec/android_get_value_from_build_action_spec.rb
+++ b/spec/android_get_value_from_build_action_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidGetValueFromBuildAction do
+  def execute_lane_test_kts(dir: '../**/kts', key: nil)
+    execute_lane_test(dir: dir, key: key)
+  end
+
   def execute_lane_test(dir: '../**/app', key: nil)
     params = [
       "app_project_dir: \"#{dir}\","
@@ -16,15 +20,25 @@ describe Fastlane::Actions::AndroidGetValueFromBuildAction do
   end
 
   describe "Get def variable" do
-    it "should return defVersionName from build.gradle" do
+    it "returns defVersionName from build.gradle" do
       result = execute_lane_test(key: "defVersionName")
+      expect(result).to eq("1.0.0")
+    end
+
+    it "returns defVersionName from build.gradle.kts" do
+      result = execute_lane_test_kts(key: "defVersionName")
       expect(result).to eq("1.0.0")
     end
   end
 
   describe "Get versionName property" do
-    it "should return versionName from build.gradle" do
+    it "returns versionName from build.gradle" do
       result = execute_lane_test(key: "versionName")
+      expect(result).to eq("1.0.0")
+    end
+
+    it "returns versionName from build.gradle.kts" do
+      result = execute_lane_test_kts(key: "versionName")
       expect(result).to eq("1.0.0")
     end
   end

--- a/spec/android_get_version_code_action_spec.rb
+++ b/spec/android_get_version_code_action_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidGetVersionCodeAction do
+  def execute_lane_test_kts(dir: '../**/kts', key: nil)
+    execute_lane_test(dir: dir, key: key)
+  end
+
   def execute_lane_test(dir: '../**/app', key: nil)
     params = [
       "app_project_dir: \"#{dir}\","
@@ -24,8 +28,20 @@ describe Fastlane::Actions::AndroidGetVersionCodeAction do
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq(result)
     end
 
+    it "returns default versionCode from build.gradle.kts" do
+      result = execute_lane_test_kts
+      expect(result).to eq(12_345)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq(result)
+    end
+
     it "returns custom def versionCode from build.gradle" do
       result = execute_lane_test(key: "defVersionCode")
+      expect(result).to eq(1)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq(result)
+    end
+
+    it "returns custom def versionCode from build.gradle.kts" do
+      result = execute_lane_test_kts(key: "defVersionCode")
       expect(result).to eq(1)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq(result)
     end
@@ -35,7 +51,7 @@ describe Fastlane::Actions::AndroidGetVersionCodeAction do
     it "throws error for invalid app project dir" do
       expect do
         execute_lane_test(dir: "invalid")
-      end.to raise_error("Couldn't find build.gradle file at path 'invalid'")
+      end.to raise_error("Couldn't find build.gradle or build.gradle.kts file at path 'invalid'")
     end
 
     it "throws error for non existing field" do
@@ -44,16 +60,34 @@ describe Fastlane::Actions::AndroidGetVersionCodeAction do
       end.to raise_error("Unable to find version code with key versionCodeNotFound on file ../**/app/build.gradle")
     end
 
+    it "throws error for non existing field in kts file" do
+      expect do
+        execute_lane_test_kts(key: "versionCodeNotFound")
+      end.to raise_error("Unable to find version code with key versionCodeNotFound on file ../**/kts/build.gradle.kts")
+    end
+
     it "throws error for invalid field" do
       expect do
         execute_lane_test(key: "versionCodeInvalid")
       end.to raise_error("Version code with key versionCodeInvalid on file ../**/app/build.gradle is invalid, it must be an integer")
     end
 
+    it "throws error for invalid field in kts file" do
+      expect do
+        execute_lane_test_kts(key: "versionCodeInvalid")
+      end.to raise_error("Version code with key versionCodeInvalid on file ../**/kts/build.gradle.kts is invalid, it must be an integer")
+    end
+
     it "throws error for invalid def field" do
       expect do
         execute_lane_test(key: "defVersionCodeInvalid")
       end.to raise_error("Version code with key defVersionCodeInvalid on file ../**/app/build.gradle is invalid, it must be an integer")
+    end
+
+    it "throws error for invalid def field in kts file" do
+      expect do
+        execute_lane_test_kts(key: "defVersionCodeInvalid")
+      end.to raise_error("Version code with key defVersionCodeInvalid on file ../**/kts/build.gradle.kts is invalid, it must be an integer")
     end
   end
 end

--- a/spec/android_get_version_name_action_spec.rb
+++ b/spec/android_get_version_name_action_spec.rb
@@ -5,6 +5,10 @@ require 'spec_helper'
 require 'semantic'
 
 describe Fastlane::Actions::AndroidGetVersionNameAction do
+  def execute_lane_test_kts(dir: '../**/kts', key: nil)
+    execute_lane_test(dir: dir, key: key)
+  end
+
   def execute_lane_test(dir: '../**/app', key: nil)
     params = [
       "app_project_dir: \"#{dir}\","
@@ -26,22 +30,49 @@ describe Fastlane::Actions::AndroidGetVersionNameAction do
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
     end
 
-    it "should return custom def versionName from build.gradle" do
+    it "returns default versionName from build.gradle.kts" do
+      result = execute_lane_test_kts
+      expect(result).to eq("1.0.0")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
+    end
+
+    it "returns custom def versionName from build.gradle" do
       result = execute_lane_test(key: "defVersionName")
       expect(result).to be_a_kind_of(Semantic::Version)
       expect(result.to_s).to eq("1.0.0")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
     end
 
-    it "should cast major to major.minor.patch from build.gradle" do
+    it "returns custom def versionName from build.gradle.kts" do
+      result = execute_lane_test_kts(key: "defVersionName")
+      expect(result).to be_a_kind_of(Semantic::Version)
+      expect(result.to_s).to eq("1.0.0")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
+    end
+
+    it "casts major to major.minor.patch from build.gradle" do
       result = execute_lane_test(key: "defVersionNameMajor")
       expect(result).to be_a_kind_of(Semantic::Version)
       expect(result.to_s).to eq("1.0.0")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
     end
 
-    it "should cast major.minor to major.minor.patch from build.gradle" do
+    it "casts major to major.minor.patch from build.gradle.kts" do
+      result = execute_lane_test_kts(key: "defVersionNameMajor")
+      expect(result).to be_a_kind_of(Semantic::Version)
+      expect(result.to_s).to eq("1.0.0")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
+    end
+
+    it "casts major.minor to major.minor.patch from build.gradle" do
       result = execute_lane_test(key: "defVersionNameMajorMinor")
+      expect(result).to be_a_kind_of(Semantic::Version)
+      expect(result.to_s).to eq("1.0.0")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
+    end
+
+    it "casts major.minor to major.minor.patch from build.gradle.kts" do
+      result = execute_lane_test_kts(key: "defVersionNameMajorMinor")
       expect(result).to be_a_kind_of(Semantic::Version)
       expect(result.to_s).to eq("1.0.0")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
@@ -52,7 +83,7 @@ describe Fastlane::Actions::AndroidGetVersionNameAction do
     it "throws error for invalid app project dir" do
       expect do
         execute_lane_test(dir: "invalid")
-      end.to raise_error("Couldn't find build.gradle file at path 'invalid'")
+      end.to raise_error("Couldn't find build.gradle or build.gradle.kts file at path 'invalid'")
     end
 
     it "throws error for non existing field" do
@@ -61,16 +92,34 @@ describe Fastlane::Actions::AndroidGetVersionNameAction do
       end.to raise_error("Unable to find version name with key versionNameNotFound on file ../**/app/build.gradle")
     end
 
+    it "throws error for non existing field in kts file" do
+      expect do
+        execute_lane_test_kts(key: "versionNameNotFound")
+      end.to raise_error("Unable to find version name with key versionNameNotFound on file ../**/kts/build.gradle.kts")
+    end
+
     it "throws error for invalid field" do
       expect do
         execute_lane_test(key: "versionNameInvalid")
       end.to raise_error("Error parsing version name with key versionNameInvalid on file ../**/app/build.gradle: 1.0.0abc is not a valid SemVer Version (http://semver.org)")
     end
 
+    it "throws error for invalid field in kts file" do
+      expect do
+        execute_lane_test_kts(key: "versionNameInvalid")
+      end.to raise_error("Error parsing version name with key versionNameInvalid on file ../**/kts/build.gradle.kts: 1.0.0abc is not a valid SemVer Version (http://semver.org)")
+    end
+
     it "throws error for invalid def field" do
       expect do
         execute_lane_test(key: "defVersionNameInvalid")
       end.to raise_error("Error parsing version name with key defVersionNameInvalid on file ../**/app/build.gradle: 1.0.0abc is not a valid SemVer Version (http://semver.org)")
+    end
+
+    it "throws error for invalid def field in kts file" do
+      expect do
+        execute_lane_test_kts(key: "defVersionNameInvalid")
+      end.to raise_error("Error parsing version name with key defVersionNameInvalid on file ../**/kts/build.gradle.kts: 1.0.0abc is not a valid SemVer Version (http://semver.org)")
     end
   end
 end

--- a/spec/android_increment_version_code_action_spec.rb
+++ b/spec/android_increment_version_code_action_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidIncrementVersionCodeAction do
+  def execute_lane_test_kts(dir: '../**/kts', key: nil, version_code: nil)
+    execute_lane_test(dir: dir, key: key, version_code: version_code)
+  end
+
   def execute_lane_test(dir: '../**/app', key: nil, version_code: nil)
     params = [
       "app_project_dir: \"#{dir}\","
@@ -24,13 +28,33 @@ describe Fastlane::Actions::AndroidIncrementVersionCodeAction do
       expect(result).to eq(12_346)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq(result)
     end
+
+    it "increments default versionCode on build.gradle.kts", :modifies_gradle do
+      result = execute_lane_test_kts
+      expect(result).to eq(12_346)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq(result)
+    end
+
     it "increments def versionCode on build.gradle", :modifies_gradle do
       result = execute_lane_test(key: "defVersionCode")
       expect(result).to eq(2)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq(result)
     end
+
+    it "increments def versionCode on build.gradle.kts", :modifies_gradle do
+      result = execute_lane_test_kts(key: "defVersionCode")
+      expect(result).to eq(2)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq(result)
+    end
+
     it "increments versionCode on build.gradle to the specified amount", :modifies_gradle do
       result = execute_lane_test(version_code: 23_456)
+      expect(result).to eq(23_456)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq(result)
+    end
+
+    it "increments versionCode on build.gradle.kts to the specified amount", :modifies_gradle do
+      result = execute_lane_test_kts(version_code: 23_456)
       expect(result).to eq(23_456)
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_CODE]).to eq(result)
     end

--- a/spec/android_increment_version_name_action_spec.rb
+++ b/spec/android_increment_version_name_action_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidIncrementVersionNameAction do
+  def execute_lane_test_kts(dir: '../**/kts', key: nil, version_name: nil, increment_type: nil)
+    execute_lane_test(dir: dir, key: key, version_name: version_name, increment_type: increment_type)
+  end
+
   def execute_lane_test(dir: '../**/app', key: nil, version_name: nil, increment_type: nil)
     params = [
       "app_project_dir: \"#{dir}\","
@@ -26,32 +30,79 @@ describe Fastlane::Actions::AndroidIncrementVersionNameAction do
       expect(result.to_s).to eq("1.0.1")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
     end
+
+    it "increments default versionName on build.gradle.kts", :modifies_gradle do
+      result = execute_lane_test_kts
+      expect(result).to be_a_kind_of(Semantic::Version)
+      expect(result.to_s).to eq("1.0.1")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
+    end
+
     it "increments def versionName on build.gradle", :modifies_gradle do
       result = execute_lane_test(key: "defVersionName")
       expect(result).to be_a_kind_of(Semantic::Version)
       expect(result.to_s).to eq("1.0.1")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
     end
+
+    it "increments def versionName on build.gradle.kts", :modifies_gradle do
+      result = execute_lane_test_kts(key: "defVersionName")
+      expect(result).to be_a_kind_of(Semantic::Version)
+      expect(result.to_s).to eq("1.0.1")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
+    end
+
     it "increments default versionName on build.gradle with patch bump", :modifies_gradle do
       result = execute_lane_test(increment_type: "patch")
       expect(result).to be_a_kind_of(Semantic::Version)
       expect(result.to_s).to eq("1.0.1")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
     end
+
+    it "increments default versionName on build.gradle.kts with patch bump", :modifies_gradle do
+      result = execute_lane_test_kts(increment_type: "patch")
+      expect(result).to be_a_kind_of(Semantic::Version)
+      expect(result.to_s).to eq("1.0.1")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
+    end
+
     it "increments default versionName on build.gradle with minor bump", :modifies_gradle do
       result = execute_lane_test(increment_type: "minor")
       expect(result).to be_a_kind_of(Semantic::Version)
       expect(result.to_s).to eq("1.1.0")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
     end
+
+    it "increments default versionName on build.gradle.kts with minor bump", :modifies_gradle do
+      result = execute_lane_test_kts(increment_type: "minor")
+      expect(result).to be_a_kind_of(Semantic::Version)
+      expect(result.to_s).to eq("1.1.0")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
+    end
+
     it "increments default versionName on build.gradle with major bump", :modifies_gradle do
       result = execute_lane_test(increment_type: "major")
       expect(result).to be_a_kind_of(Semantic::Version)
       expect(result.to_s).to eq("2.0.0")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
     end
+
+    it "increments default versionName on build.gradle.kts with major bump", :modifies_gradle do
+      result = execute_lane_test_kts(increment_type: "major")
+      expect(result).to be_a_kind_of(Semantic::Version)
+      expect(result.to_s).to eq("2.0.0")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
+    end
+
     it "increments versionCode on build.gradle to the specified amount", :modifies_gradle do
       result = execute_lane_test(version_name: "2.3.4")
+      expect(result).to be_a_kind_of(Semantic::Version)
+      expect(result.to_s).to eq("2.3.4")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
+    end
+
+    it "increments versionCode on build.gradle.kts to the specified amount", :modifies_gradle do
+      result = execute_lane_test_kts(version_name: "2.3.4")
       expect(result).to be_a_kind_of(Semantic::Version)
       expect(result.to_s).to eq("2.3.4")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::ANDROID_VERSION_NAME]).to eq(result)
@@ -64,10 +115,15 @@ describe Fastlane::Actions::AndroidIncrementVersionNameAction do
       execute_lane_test(version_name: "0.0.1")
     end
 
+    it "show message if newer version name is lower than the current value in kts file", :modifies_gradle do
+      expect(Fastlane::UI).to receive(:important).with("New version name is not greater than the current one")
+      execute_lane_test_kts(version_name: "0.0.1")
+    end
+
     it "throws error for invalid app project dir" do
       expect do
         execute_lane_test(dir: "invalid")
-      end.to raise_error("Couldn't find build.gradle file at path 'invalid'")
+      end.to raise_error("Couldn't find build.gradle or build.gradle.kts file at path 'invalid'")
     end
 
     it "throws error for non existing field" do
@@ -76,10 +132,22 @@ describe Fastlane::Actions::AndroidIncrementVersionNameAction do
       end.to raise_error("Unable to find version name with key versionNameNotFound on file ../**/app/build.gradle")
     end
 
+    it "throws error for non existing field in kts file" do
+      expect do
+        execute_lane_test_kts(key: "versionNameNotFound")
+      end.to raise_error("Unable to find version name with key versionNameNotFound on file ../**/kts/build.gradle.kts")
+    end
+
     it "throws error for invalid field" do
       expect do
         execute_lane_test(key: "versionNameInvalid")
       end.to raise_error("Error parsing version name with key versionNameInvalid on file ../**/app/build.gradle: 1.0.0abc is not a valid SemVer Version (http://semver.org)")
+    end
+
+    it "throws error for invalid field in kts file" do
+      expect do
+        execute_lane_test_kts(key: "versionNameInvalid")
+      end.to raise_error("Error parsing version name with key versionNameInvalid on file ../**/kts/build.gradle.kts: 1.0.0abc is not a valid SemVer Version (http://semver.org)")
     end
 
     it "throws error for invalid def field" do
@@ -88,9 +156,21 @@ describe Fastlane::Actions::AndroidIncrementVersionNameAction do
       end.to raise_error("Error parsing version name with key defVersionNameInvalid on file ../**/app/build.gradle: 1.0.0abc is not a valid SemVer Version (http://semver.org)")
     end
 
+    it "throws error for invalid def field in kts file" do
+      expect do
+        execute_lane_test_kts(key: "defVersionNameInvalid")
+      end.to raise_error("Error parsing version name with key defVersionNameInvalid on file ../**/kts/build.gradle.kts: 1.0.0abc is not a valid SemVer Version (http://semver.org)")
+    end
+
     it "throws error for invalid increment type field" do
       expect do
         execute_lane_test(increment_type: "majora") # mask
+      end.to raise_error("Increment type of majora is not valid")
+    end
+
+    it "throws error for invalid increment type field in kts file" do
+      expect do
+        execute_lane_test_kts(increment_type: "majora") # mask
       end.to raise_error("Increment type of majora is not valid")
     end
   end

--- a/spec/fixtures/kts/build.gradle.kts
+++ b/spec/fixtures/kts/build.gradle.kts
@@ -1,0 +1,21 @@
+defVersionCode = 1 // comment
+defVersionCodeInvalid = "a" // comment
+
+defVersionName = "1.0.0" // comment
+defVersionNameInvalid = "1.0.0abc" // comment
+
+android {
+  compileSdkVersion(24)
+  buildToolsVersion("24.0.2")
+  defaultConfig {
+    applicationIdSuffix = ""
+    minSdkVersion(14)
+    targetSdkVersion(22)
+    versionCode = 12345 // comment
+    versionCodeInvalid = "a" // comment
+    versionName = "1.0.0" // comment
+    defVersionNameMajor = "1" // comment
+    defVersionNameMajorMinor = "1.0" // comment
+    versionNameInvalid = "1.0.0abc" // comment
+  }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,7 @@ def revert_fixtures
   destination = "./spec"
   [
     "#{destination}/fixtures/app/build.gradle",
+    "#{destination}/fixtures/kts/build.gradle.kts"
   ].each do |f|
     FileUtils.rm(f)
   end


### PR DESCRIPTION
This PR adds support for KTS build files.

I also refactored some code to remove duplications.

Thank you for this great plugin !

Nicolas